### PR TITLE
Always return lists as cif_dictionary values

### DIFF
--- a/src/pdbecif/mmcif_tools.py
+++ b/src/pdbecif/mmcif_tools.py
@@ -316,17 +316,13 @@ class MMCIF2Dict:
                             else:
                                 if category in data_block:
                                     data_block[category].update(
-                                        {item: value if len(value) > 1 else value[0]}
+                                        {item: value}
                                     )
                                 else:
                                     data_block.setdefault(
                                         category,
                                         _dict(
-                                            {
-                                                item: value
-                                                if len(value) > 1
-                                                else value[0]
-                                            }
+                                            {item: value}
                                         ),
                                     )  # OrderedDict here preserves item order
                         else:


### PR DESCRIPTION
Always use lists as dictionary values (instead of a single string if there is a single value) to facilitate the programatic use of data, e.g. always being able to transform the dictionary to a pandas DataFrame for visual inspection or management without having to take care of the dictionary's values types, or iterate through the values without risking iterating through the characters of a single string.
If necessary, I could add an argument to the MMCIF2Dict class to be able to choose.